### PR TITLE
fix: Synchronize monitor index between runtime and config

### DIFF
--- a/src-lib/private/settings.rs
+++ b/src-lib/private/settings.rs
@@ -315,6 +315,11 @@ impl Settings {
         debug_println!("placing window at {}, {}", window_x, window_y);
         PhysicalPosition::new(window_x, window_y)
     }
+
+    pub fn set_monitor(&mut self, monitor_index: usize) {
+        self.monitor_index = monitor_index;
+        self.persisted.monitor = (monitor_index as u32) + 1;
+    }
 }
 
 impl Default for Settings {

--- a/src/window.rs
+++ b/src/window.rs
@@ -214,8 +214,8 @@ impl<'a> ApplicationHandler<UserEvent> for State<'a> {
             }
 
             if self.hotkey_manager.cycle_monitor() {
-                self.settings.monitor_index =
-                    (self.settings.monitor_index + 1) % window.available_monitors().count();
+                let next_monitor = (self.settings.monitor_index + 1) % window.available_monitors().count();
+                self.settings.set_monitor(next_monitor);
                 self.window_scale_dirty = true;
             }
 


### PR DESCRIPTION
When cycling through monitors with Ctrl+M, ensure both the runtime monitor_index and the persisted monitor value are properly synchronized.